### PR TITLE
Autobuild amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # robosub-ros-docker
+![Docker Hub Builds](https://img.shields.io/docker/cloud/build/dukerobotics/robosub-ros)
+![Docker Pulls](https://img.shields.io/docker/pulls/dukerobotics/robosub-ros)
 Docker image for ROS system to control a robot for the RoboSub Competition
 
 ## Summary

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -22,26 +22,26 @@ WORKDIR $WORKDIR
 
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-	openssh-server \
-	x11-apps xauth \
-	vim \
-	curl \
-	sudo \
-    	usbutils \
-    	apt-utils \
-	python-catkin-tools \
-	python-pip \
-    	locales \
-    	libceres-dev \
-    	ros-kinetic-desktop-full \
-    	ros-kinetic-mavros ros-kinetic-mavros-extras \
-    	ros-kinetic-robot-localization  ros-kinetic-libg2o \
-    	ros-kinetic-pid ros-kinetic-camera-info-manager-py \
-    	ros-kinetic-rosserial ros-kinetic-rosserial-arduino \
-    	ros-kinetic-rosbridge-suite && \
-    	apt-get clean && \
-    	# Clear apt caches to reduce image size
-    	rm -rf /var/lib/apt/lists/*
+    openssh-server \
+    x11-apps xauth \
+    vim \
+    curl \
+    sudo \
+    usbutils \
+    apt-utils \
+    python-catkin-tools \
+    python-pip \
+    locales \
+    libceres-dev \
+    ros-kinetic-desktop-full \
+    ros-kinetic-mavros ros-kinetic-mavros-extras \
+    ros-kinetic-robot-localization  ros-kinetic-libg2o \
+    ros-kinetic-pid ros-kinetic-camera-info-manager-py \
+    ros-kinetic-rosserial ros-kinetic-rosserial-arduino \
+    ros-kinetic-rosbridge-suite && \
+    apt-get clean && \
+    # Clear apt caches to reduce image size
+    rm -rf /var/lib/apt/lists/*
 
 # Get required python packages
 RUN pip install pyserial dependency-injector

--- a/latest/README.md
+++ b/latest/README.md
@@ -1,18 +1,64 @@
 # Dockerfile Notes
-  
-## Building
 
-- Building should be done by the maintainer of the Dockerfile, and published so that others can follow the 'Running' instructions to use the image
+## Tags
+This Dockerfile is used to generate three differently tagged images.
+
+1. `amd64`: A Docker image built to be run on development computers and the NUC (and any other 64 bit x86 system).
+2. `arm64`: A Docker image built to be run on the Jetson.
+3. `latest`: A Docker manifest list. Pulling `latest` will automatically choose between an ARM and x86 image depending on your system. This is the one you should use in most cases.
+
+## Building
+- Building should be done by the maintainer of the Dockerfile, and published so that others can follow the 'Running' instructions to use the image.
 
 - Buildx is currently experimental, for details, see [here](https://docs.docker.com/buildx/working-with-buildx/)
 
-- Experimental features in Docker must be enabled, go to Docker Preferences -> Docker Engine and set experimental to 'true'
+- Experimental features in Docker must be enabled to use buildx, go to Docker Preferences -> Docker Engine and set experimental to 'true'.
 
-1. ```cd``` into the directory containing the Dockerfile
+- All these commands must be executed in the directory containing the Dockerfile.
 
-2. Build
+### Updating the manifest list
+After each build and push of the `arm64` or `amd64` tags, you should ensure that the images used for the `latest` tag are up to date. This means pointing the `latest` tag to the newly built images. In order to do so, you will need to create and push a new manifest list:
+
+```bash
+docker manifest create dukerobotics/robosub-ros:latest dukerobotics/robosub-ros:arm64 dukerobotics/robosub-ros:amd64
+
+docker manifest push -p dukerobotics/robosub-ros:latest
+```
+
+In the event that you get an error about an existing manifest list, check `~/.docker/manifests` to see if there are any existing manifests
+that match. If so, delete them and run the commands again.
+### `arm64`
+
+ARM builds are currently not supported for autobuilds. Rebuilding the ARM image should be the most common case for manually building this Dockerfile. Run the below command to build and push a new ARM image with the `arm64` tag.
+
+```bash
+docker buildx build --platform linux/arm64 -t dukerobotics/robosub-ros:arm64 --push .
+```
+
+Now to update the manifest list for `latest` run the command in the section on updating the manifest list.
+
+### `amd64`
+
+The `amd64` tag is set to autobuild on Docker Hub. Updates to master will therefore be reflected in the image around an hour after they are pushed. If there is ever a need to manually build and push the `amd64` tag, use the following commands:
+
+```bash
+docker build --build-arg TARGETPLATFORM=linux/amd64 -t dukerobotics/robosub-ros:amd64 .
+
+docker push dukerobotics/robosub-ros:amd64
+```
+
+We now have the new image pushed to Docker Hub. Please note that any subsequent commit to master will erase this image.
+
+Now to update the manifest list for `latest` run the command in the section on updating the manifest list.
+
+
+
+### `latest`
+The following command will build a new arm64 and amd64 image but **does not** update the `arm64` and `amd64` tags. Instead, it will push the new images directly to `latest`.
+
+This command is therefore not recommended, since it can lead to the images falling out of sync.
+
 ```bash
 docker buildx build --platform linux/amd64,linux/arm64 -t dukerobotics/robosub-ros:latest --push .
 ```
-
 

--- a/latest/clone-and-build.test.yml
+++ b/latest/clone-and-build.test.yml
@@ -2,9 +2,8 @@
 sut:
   image: ${IMAGE_NAME}
   command: sudo su duke
-           cd ~ && \
+           cd ~/dev && \
            git clone https://github.com/DukeRobotics/robosub-ros.git && \
-           cp -r robosub-ros/src dev/robosub-ros/catkin_ws && \
            source /opt/ros/kinetic/setup.bash && \
-           cd dev/robosub-ros/catkin_ws && \
+           cd robosub-ros/catkin_ws && \
            catkin build

--- a/latest/clone-and-build.test.yml
+++ b/latest/clone-and-build.test.yml
@@ -1,7 +1,8 @@
 
 sut:
-  build: .
-  command: cd ~ && \
+  image: ${IMAGE_NAME}
+  command: sudo su duke
+           cd ~ && \
            git clone https://github.com/DukeRobotics/robosub-ros.git && \
            cp -r robosub-ros/src dev/robosub-ros/catkin_ws && \
            source /opt/ros/kinetic/setup.bash && \

--- a/latest/clone-and-build.test.yml
+++ b/latest/clone-and-build.test.yml
@@ -1,0 +1,9 @@
+
+sut:
+  build: .
+  command: cd ~ && \
+           git clone https://github.com/DukeRobotics/robosub-ros.git && \
+           cp -r robosub-ros/src dev/robosub-ros/catkin_ws && \
+           source /opt/ros/kinetic/setup.bash && \
+           cd dev/robosub-ros/catkin_ws && \
+           catkin build

--- a/latest/hooks/build
+++ b/latest/hooks/build
@@ -1,0 +1,1 @@
+docker build --build-arg TARGETPLATFORM=linux/amd64 -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/latest/hooks/build
+++ b/latest/hooks/build
@@ -1,1 +1,2 @@
+#!/bin/bash
 docker build --build-arg TARGETPLATFORM=linux/amd64 -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/latest/hooks/post_push
+++ b/latest/hooks/post_push
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker manifest create dukerobotics/robosub-ros:latest dukerobotics/robosub-ros:arm64 dukerobotics/robosub-ros:amd64
+docker manifest push -p dukerobotics/robosub-ros:latest

--- a/latest/hooks/pre_build
+++ b/latest/hooks/pre_build
@@ -1,0 +1,3 @@
+#!/bin/bash
+apt-get -y update
+apt-get -y --only-upgrade install docker-ee


### PR DESCRIPTION
Add build hook to allow automated build for the main image. Note that this will only build the image for amd64 and will push it to the amd64 tag in the registry.