### PR TITLE
Add wget and mosh to dockerfiles

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -21,9 +21,10 @@ WORKDIR $WORKDIR
 ### Basic Setup ###
 
 # Update and install tools
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    openssh-server \
-    mosh \
+RUN apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:jgmath2000/et && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    openssh-server mosh et \
     x11-apps xauth \
     vim \
     curl \

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -23,9 +23,11 @@ WORKDIR $WORKDIR
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-server \
+    mosh \
     x11-apps xauth \
     vim \
     curl \
+    wget \
     sudo \
     usbutils \
     apt-utils \

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR $WORKDIR
 ### Basic Setup ###
 
 # Update and install tools
-RUN apt-get install -y --no-install-recommends software-properties-common && \
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:jgmath2000/et && \
     apt-get update && apt-get install -y --no-install-recommends \
     openssh-server mosh et \

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /home/duke/dev
 
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
     ros-kinetic-geometry2 \
     xsltproc && \
     apt-get clean && \

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /home/duke/dev
 
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget \
     ros-kinetic-geometry2 \
     xsltproc && \
     apt-get clean && \


### PR DESCRIPTION
Wget is needed for simulation dockerfile to build. Mosh can be used instead of ssh when we want a persistent connection when we have issues with maintaining a steady connection.