### PR TITLE
Integrate GPU and upgrade to ros melodic

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,76 +10,15 @@ on:
   pull_request:
 
 jobs:
-  base-arm64:
-    runs-on: ubuntu-latest
-    env:
-      BASE_IMAGE: nvcr.io/nvidia/l4t-base:r32.3.1
-      IMAGE_NAME: dukerobotics/robosub-ros:base-arm64
-    steps:
-      - uses: actions/checkout@v2
-      - name: Pull and tag l4t image
-        run: |
-          docker pull ${BASE_IMAGE}
-          docker tag ${BASE_IMAGE} ${IMAGE_NAME}
-      - name: Push image
-        if: github.event_name == 'push'
-        run: |
-          echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
-          docker push ${IMAGE_NAME}
-      - name: Save image
-        run: |
-          docker save ${IMAGE_NAME} | gzip > base-arm64.tar.gz
-      - name: Create artifact from image
-        uses: actions/upload-artifact@v1
-        with:
-          name: base-arm64
-          path: base-arm64.tar.gz
-
-
-  base-amd64:
-    runs-on: ubuntu-latest
-    env:
-      BASE_IMAGE: ubuntu:bionic
-      IMAGE_NAME: dukerobotics/robosub-ros:base-amd64
-    steps:
-      - uses: actions/checkout@v2
-      - name: Pull and tag bionic image
-        run: |
-          docker pull ${BASE_IMAGE}
-          docker tag ${BASE_IMAGE} ${IMAGE_NAME}
-      - name: Push image
-        if: github.event_name == 'push'
-        run: |
-          echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
-          docker push ${IMAGE_NAME}
-      - name: Save image
-        run: |
-          docker save ${IMAGE_NAME} | gzip > base-amd64.tar.gz
-      - name: Create artifact from image
-        uses: actions/upload-artifact@v1
-        with:
-          name: base-amd64
-          path: base-amd64.tar.gz
-
-
   core-arm64:
     runs-on: ubuntu-latest
-    needs: base-arm64
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:core-arm64
       TARGETPLATFORM: linux/arm64
       FOLDER_NAME: core
-      BASE_IMAGE: dukerobotics/robosub-ros:base-arm64
+      BASE_IMAGE: dukerobotics/robosub-ros:base
     steps:
       - uses: actions/checkout@v2
-      - name: Get base image
-        uses: actions/download-artifact@v1
-        with: 
-          name: base-arm64
-      - name: Load core image
-        run: |
-          docker load < ./base-arm64/base-arm64.tar.gz
-          rm -rf base-arm64
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
@@ -99,22 +38,13 @@ jobs:
 
   core-amd64:
     runs-on: ubuntu-latest
-    needs: base-amd64
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:core-amd64
       TARGETPLATFORM: linux/amd64
       FOLDER_NAME: core
-      BASE_IMAGE: dukerobotics/robosub-ros:base-amd64
+      BASE_IMAGE: dukerobotics/robosub-ros:base
     steps:
       - uses: actions/checkout@v2
-      - name: Get base image
-        uses: actions/download-artifact@v1
-        with: 
-          name: base-amd64
-      - name: Load core image
-        run: |
-          docker load < ./base-amd64/base-amd64.tar.gz
-          rm -rf base-amd64
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
@@ -198,7 +128,6 @@ jobs:
         run: |
           ./.github/workflows/setup.sh
           echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
-          docker buildx imagetools create --tag dukerobotics/robosub-ros:base dukerobotics/robosub-ros:base-amd64 dukerobotics/robosub-ros:base-arm64
           docker buildx imagetools create --tag dukerobotics/robosub-ros:core dukerobotics/robosub-ros:core-amd64 dukerobotics/robosub-ros:core-arm64
           docker buildx imagetools create --tag dukerobotics/robosub-ros:onboard dukerobotics/robosub-ros:onboard-amd64 dukerobotics/robosub-ros:onboard-arm64
       - name: Cleanup artifacts

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
       IMAGE_NAME: dukerobotics/robosub-ros:core-arm64
       TARGETPLATFORM: linux/arm64
       FOLDER_NAME: core
-      BASE_IMAGE: ros:kinetic-ros-core-xenial
+      BASE_IMAGE: ros:melodic-ros-core-bionic
     steps:
       - uses: actions/checkout@v2
       - name: Setup environment and build
@@ -42,7 +42,7 @@ jobs:
       IMAGE_NAME: dukerobotics/robosub-ros:core-amd64
       TARGETPLATFORM: linux/amd64
       FOLDER_NAME: core
-      BASE_IMAGE: ros:kinetic-ros-core-xenial
+      BASE_IMAGE: ros:melodic-ros-core-bionic
     steps:
       - uses: actions/checkout@v2
       - name: Setup environment and build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,15 +10,76 @@ on:
   pull_request:
 
 jobs:
+  base-arm64:
+    runs-on: ubuntu-latest
+    env:
+      BASE_IMAGE: nvcr.io/nvidia/l4t-base:r32.3.1
+      IMAGE_NAME: dukerobotics/robosub-ros:base-arm64
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull and tag l4t image
+        run: |
+          docker pull ${BASE_IMAGE}
+          docker tag ${BASE_IMAGE} ${IMAGE_NAME}
+      - name: Push image
+        if: github.event_name == 'push'
+        run: |
+          echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
+          docker push ${IMAGE_NAME}
+      - name: Save image
+        run: |
+          docker save ${IMAGE_NAME} | gzip > base-arm64.tar.gz
+      - name: Create artifact from image
+        uses: actions/upload-artifact@v1
+        with:
+          name: base-arm64
+          path: base-arm64.tar.gz
+
+
+  base-amd64:
+    runs-on: ubuntu-latest
+    env:
+      BASE_IMAGE: ubuntu:bionic
+      IMAGE_NAME: dukerobotics/robosub-ros:base-amd64
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull and tag bionic image
+        run: |
+          docker pull ${BASE_IMAGE}
+          docker tag ${BASE_IMAGE} ${IMAGE_NAME}
+      - name: Push image
+        if: github.event_name == 'push'
+        run: |
+          echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
+          docker push ${IMAGE_NAME}
+      - name: Save image
+        run: |
+          docker save ${IMAGE_NAME} | gzip > base-amd64.tar.gz
+      - name: Create artifact from image
+        uses: actions/upload-artifact@v1
+        with:
+          name: base-amd64
+          path: base-amd64.tar.gz
+
+
   core-arm64:
     runs-on: ubuntu-latest
+    needs: base-arm64
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:core-arm64
       TARGETPLATFORM: linux/arm64
       FOLDER_NAME: core
-      BASE_IMAGE: ubuntu:bionic
+      BASE_IMAGE: dukerobotics/robosub-ros:base-arm64
     steps:
       - uses: actions/checkout@v2
+      - name: Get base image
+        uses: actions/download-artifact@v1
+        with: 
+          name: base-arm64
+      - name: Load core image
+        run: |
+          docker load < ./base-arm64/base-arm64.tar.gz
+          rm -rf base-arm64
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
@@ -29,22 +90,31 @@ jobs:
           docker push ${IMAGE_NAME}
       - name: Save image
         run: |
-          docker save ${IMAGE_NAME} | gzip > arm64.tar.gz
+          docker save ${IMAGE_NAME} | gzip > core-arm64.tar.gz
       - name: Create artifact from image
         uses: actions/upload-artifact@v1
         with:
-          name: arm64
-          path: arm64.tar.gz
+          name: core-arm64
+          path: core-arm64.tar.gz
 
   core-amd64:
     runs-on: ubuntu-latest
+    needs: base-amd64
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:core-amd64
       TARGETPLATFORM: linux/amd64
       FOLDER_NAME: core
-      BASE_IMAGE: ubuntu:bionic
+      BASE_IMAGE: dukerobotics/robosub-ros:base-amd64
     steps:
       - uses: actions/checkout@v2
+      - name: Get base image
+        uses: actions/download-artifact@v1
+        with: 
+          name: base-amd64
+      - name: Load core image
+        run: |
+          docker load < ./base-amd64/base-amd64.tar.gz
+          rm -rf base-amd64
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
@@ -55,12 +125,12 @@ jobs:
           docker push ${IMAGE_NAME}
       - name: Save image
         run: |
-          docker save ${IMAGE_NAME} | gzip > amd64.tar.gz
+          docker save ${IMAGE_NAME} | gzip > core-amd64.tar.gz
       - name: Create artifact from image
         uses: actions/upload-artifact@v1
         with:
-          name: amd64
-          path: amd64.tar.gz
+          name: core-amd64
+          path: core-amd64.tar.gz
 
   onboard-arm64:
     runs-on: ubuntu-latest
@@ -75,11 +145,11 @@ jobs:
       - name: Get core image
         uses: actions/download-artifact@v1
         with: 
-          name: arm64
+          name: core-arm64
       - name: Load core image
         run: |
-          docker load < ./arm64/arm64.tar.gz
-          rm -rf arm64
+          docker load < ./core-arm64/core-arm64.tar.gz
+          rm -rf core-arm64
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
@@ -103,11 +173,11 @@ jobs:
       - name: Get core image
         uses: actions/download-artifact@v1
         with: 
-          name: amd64
+          name: core-amd64
       - name: Load core image
         run: |
-          docker load < ./amd64/amd64.tar.gz
-          rm -rf amd64
+          docker load < ./core-amd64/core-amd64.tar.gz
+          rm -rf core-amd64
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
@@ -128,6 +198,7 @@ jobs:
         run: |
           ./.github/workflows/setup.sh
           echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
+          docker buildx imagetools create --tag dukerobotics/robosub-ros:base dukerobotics/robosub-ros:base-amd64 dukerobotics/robosub-ros:base-arm64
           docker buildx imagetools create --tag dukerobotics/robosub-ros:core dukerobotics/robosub-ros:core-amd64 dukerobotics/robosub-ros:core-arm64
           docker buildx imagetools create --tag dukerobotics/robosub-ros:onboard dukerobotics/robosub-ros:onboard-amd64 dukerobotics/robosub-ros:onboard-arm64
       - name: Cleanup artifacts

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
       IMAGE_NAME: dukerobotics/robosub-ros:core-arm64
       TARGETPLATFORM: linux/arm64
       FOLDER_NAME: core
-      BASE_IMAGE: ros:melodic-ros-core-bionic
+      BASE_IMAGE: ubuntu:bionic
     steps:
       - uses: actions/checkout@v2
       - name: Setup environment and build
@@ -42,7 +42,7 @@ jobs:
       IMAGE_NAME: dukerobotics/robosub-ros:core-amd64
       TARGETPLATFORM: linux/amd64
       FOLDER_NAME: core
-      BASE_IMAGE: ros:melodic-ros-core-bionic
+      BASE_IMAGE: ubuntu:bionic
     steps:
       - uses: actions/checkout@v2
       - name: Setup environment and build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -217,11 +217,11 @@ jobs:
       - name: Get core image
         uses: actions/download-artifact@v1
         with: 
-          name: amd64
+          name: core-amd64
       - name: Load core image
         run: |
-          docker load < ./amd64/amd64.tar.gz
-          rm -rf amd64
+          docker load < ./core-amd64/core-amd64.tar.gz
+          rm -rf core-amd64
       - name: Setup environment and build
         working-directory: 
         run: |

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE=dukerobotics/robosub-ros:base
-FROM ${BASE_IMAGE}
+FROM dukerobotics/robosub-ros:base
 
 ### Arguments ###
 ARG BUILD_DIR_NAME=docker-build

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,14 +1,49 @@
-ARG BASE_IMAGE=ros:melodic-ros-core-bionic
+ARG BASE_IMAGE=ubuntu:bionic
 FROM ${BASE_IMAGE}
 
 ### Arguments ###
 ARG BUILD_DIR_NAME=docker-build
 ENV WORKDIR=/root/$BUILD_DIR_NAME
 
-### Basic Setup ###
-
 # Set the workdir
 WORKDIR $WORKDIR
+
+### ROS Installation ###
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros1-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO melodic
+# bootstrap rosdep
+RUN rosdep init && \
+    rosdep update --rosdistro $ROS_DISTRO
+
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    ros-melodic-ros-core=1.4.1-0* \
+    && rm -rf /var/lib/apt/lists/*
+
+### Basic Setup ###
 
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && \

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ros:kinetic-ros-core-xenial
+ARG BASE_IMAGE=ros:melodic-ros-core-bionic
 FROM ${BASE_IMAGE}
 
 ### Arguments ###

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:bionic
+ARG BASE_IMAGE=dukerobotics/robosub-ros:base
 FROM ${BASE_IMAGE}
 
 ### Arguments ###

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -3,6 +3,7 @@ FROM ${BASE_IMAGE}
 
 ### Arguments ###
 ARG BUILD_DIR_NAME=docker-build
+ARG DEBIAN_FRONTEND=noninteractive
 ENV WORKDIR=/root/$BUILD_DIR_NAME
 
 # Set the workdir

--- a/landside/Dockerfile
+++ b/landside/Dockerfile
@@ -12,8 +12,8 @@ RUN echo "X11UseLocalhost no" >> /etc/ssh/sshd_config && \
 
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-kinetic-geometry2 ros-kinetic-rviz \
-    ros-kinetic-joy ros-kinetic-rosbridge-suite \
+    ros-melodic-geometry2 ros-melodic-rviz \
+    ros-melodic-joy ros-melodic-rosbridge-suite \
     xsltproc && \
     apt-get clean && \
     # Clear apt caches to reduce image size
@@ -29,8 +29,8 @@ RUN wget coppeliarobotics.com/files/CoppeliaSim_Edu_V4_0_0_Ubuntu16_04.tar.xz &&
 ### Final Setup ###
 
 # Add script to setup multiple machines for pool testing
-COPY setup_pool.bash /opt/ros/kinetic/setup_pool.bash
-RUN chmod +x /opt/ros/kinetic/setup_pool.bash
+COPY setup_pool.bash /opt/ros/melodic/setup_pool.bash
+RUN chmod +x /opt/ros/melodic/setup_pool.bash
 
 # Set computer type
 ENV COMPUTER_TYPE=landside

--- a/onboard/Dockerfile
+++ b/onboard/Dockerfile
@@ -13,10 +13,10 @@ RUN sed -i "s/Port 22/Port 2200/" /etc/ssh/sshd_config
 # Update and install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libceres-dev \
-    ros-kinetic-cv-bridge ros-kinetic-tf \
-    ros-kinetic-robot-localization  ros-kinetic-libg2o \
-    ros-kinetic-pid ros-kinetic-camera-info-manager-py \
-    ros-kinetic-rosserial ros-kinetic-rosserial-arduino && \
+    ros-melodic-cv-bridge ros-melodic-tf \
+    ros-melodic-robot-localization  ros-melodic-libg2o \
+    ros-melodic-pid ros-melodic-camera-info-manager-py \
+    ros-melodic-rosserial ros-melodic-rosserial-arduino && \
     apt-get clean && \
     # Clear apt caches to reduce image size
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This creates a base image, so that we may specify which image to use to start (NVIDIA's provided image for arm64 for the Jetson, or ubuntu for amd64). Doing this allows us to access the GPU on the Jetson.