### PR TITLE
Use build matrix for autobuild

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,14 +41,19 @@ jobs:
           name: core
           path: ${{ env.FILE_NAME }}
 
-  onboard-arm64:
+  onboard:
     runs-on: ubuntu-latest
     needs: core
+    strategy:
+      matrix:
+        arch: [arm64, amd64]
+      fail-fast: false
     env:
-      IMAGE_NAME: dukerobotics/robosub-ros:onboard-arm64
-      TARGETPLATFORM: linux/arm64
+      IMAGE_NAME: 'dukerobotics/robosub-ros:onboard-${{ matrix.arch }}'
+      TARGETPLATFORM: 'linux/${{ matrix.arch }}'
       FOLDER_NAME: onboard
-      BASE_IMAGE: dukerobotics/robosub-ros:core-arm64
+      BASE_IMAGE: 'dukerobotics/robosub-ros:core-${{ matrix.arch }}'
+      FILE_NAME: '${{ matrix.arch }}-core.tar.gz'
     steps:
       - uses: actions/checkout@v2
       - name: Get core image
@@ -58,36 +63,7 @@ jobs:
           path: core
       - name: Load core image
         run: |
-          docker load < ./core/arm64-core.tar.gz
-          rm -rf core
-      - name: Setup environment and build
-        run: |
-          ./.github/workflows/build.sh
-          ./.github/workflows/test.sh
-      - name: Push image
-        if: github.event_name == 'push'
-        run: |
-          echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
-          docker push ${IMAGE_NAME}
-
-  onboard-amd64:
-    runs-on: ubuntu-latest
-    needs: core
-    env:
-      IMAGE_NAME: dukerobotics/robosub-ros:onboard-amd64
-      TARGETPLATFORM: linux/amd64
-      FOLDER_NAME: onboard
-      BASE_IMAGE: dukerobotics/robosub-ros:core-amd64
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get core image
-        uses: actions/download-artifact@v2
-        with: 
-          name: core
-          path: core
-      - name: Load core image
-        run: |
-          docker load < ./core/amd64-core.tar.gz
+          docker load < ./core/${FILE_NAME}
           rm -rf core
       - name: Setup environment and build
         run: |
@@ -101,7 +77,7 @@ jobs:
 
   push:
     runs-on: ubuntu-latest
-    needs: [onboard-arm64, onboard-amd64]
+    needs: onboard
     steps:
       - uses: actions/checkout@v2
       - name: Push images to latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           docker save ${IMAGE_NAME} | gzip > core-arm64.tar.gz
       - name: Create artifact from image
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
-          name: core-arm64
+          name: core
           path: core-arm64.tar.gz
 
   core-amd64:
@@ -57,9 +57,9 @@ jobs:
         run: |
           docker save ${IMAGE_NAME} | gzip > core-amd64.tar.gz
       - name: Create artifact from image
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
-          name: core-amd64
+          name: core
           path: core-amd64.tar.gz
 
   onboard-arm64:
@@ -73,12 +73,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get core image
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with: 
-          name: core-arm64
+          name: core
+          path: core
       - name: Load core image
         run: |
-          docker load < ./core-arm64/core-arm64.tar.gz
+          docker load < ./core/core-arm64.tar.gz
           rm -rf core-arm64
       - name: Setup environment and build
         run: |
@@ -101,12 +102,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get core image
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with: 
-          name: core-amd64
+          name: core
+          path: core
       - name: Load core image
         run: |
-          docker load < ./core-amd64/core-amd64.tar.gz
+          docker load < ./core/core-amd64.tar.gz
           rm -rf core-amd64
       - name: Setup environment and build
         run: |
@@ -144,12 +146,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2 
       - name: Get core image
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with: 
-          name: core-amd64
+          name: core
+          path: core
       - name: Load core image
         run: |
-          docker load < ./core-amd64/core-amd64.tar.gz
+          docker load < ./core/core-amd64.tar.gz
           rm -rf core-amd64
       - name: Setup environment and build
         working-directory: 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
-      - name: Push image
+      - name: Push image to dockerhub
         if: github.event_name == 'push'
         run: |
           echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
@@ -69,7 +69,7 @@ jobs:
         run: |
           ./.github/workflows/build.sh
           ./.github/workflows/test.sh
-      - name: Push image
+      - name: Push image to dockerhub
         if: github.event_name == 'push'
         run: |
           echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
@@ -80,7 +80,7 @@ jobs:
     needs: onboard
     steps:
       - uses: actions/checkout@v2
-      - name: Push images to latest
+      - name: Push images to latest on dockerhub
         if: github.event_name == 'push'
         run: |
           ./.github/workflows/setup.sh
@@ -110,11 +110,10 @@ jobs:
           docker load < ./core/amd64-core.tar.gz
           rm -rf core
       - name: Setup environment and build
-        working-directory: 
         run: |
           cd landside
           docker build --build-arg BASE_IMAGE=${BASE_IMAGE} -t  ${IMAGE_NAME} .
-      - name: Push image
+      - name: Push image to dockerhub
         if: github.event_name == 'push'
         run: |
           echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,13 +10,18 @@ on:
   pull_request:
 
 jobs:
-  core-arm64:
+  core:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [arm64, amd64]
+      fail-fast: false
     env:
-      IMAGE_NAME: dukerobotics/robosub-ros:core-arm64
-      TARGETPLATFORM: linux/arm64
+      IMAGE_NAME: 'dukerobotics/robosub-ros:core-${{ matrix.arch }}'
+      TARGETPLATFORM: 'linux/${{ matrix.arch }}'
       FOLDER_NAME: core
       BASE_IMAGE: dukerobotics/robosub-ros:base
+      FILE_NAME: '${{ matrix.arch }}-core.tar.gz'
     steps:
       - uses: actions/checkout@v2
       - name: Setup environment and build
@@ -29,42 +34,16 @@ jobs:
           docker push ${IMAGE_NAME}
       - name: Save image
         run: |
-          docker save ${IMAGE_NAME} | gzip > core-arm64.tar.gz
+          docker save ${IMAGE_NAME} | gzip > ${FILE_NAME}
       - name: Create artifact from image
         uses: actions/upload-artifact@v2
         with:
           name: core
-          path: core-arm64.tar.gz
-
-  core-amd64:
-    runs-on: ubuntu-latest
-    env:
-      IMAGE_NAME: dukerobotics/robosub-ros:core-amd64
-      TARGETPLATFORM: linux/amd64
-      FOLDER_NAME: core
-      BASE_IMAGE: dukerobotics/robosub-ros:base
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup environment and build
-        run: |
-          ./.github/workflows/build.sh
-      - name: Push image
-        if: github.event_name == 'push'
-        run: |
-          echo "${{ secrets.DOCKER_BOT_TOKEN }}" | docker login -u dukeroboticsbot --password-stdin
-          docker push ${IMAGE_NAME}
-      - name: Save image
-        run: |
-          docker save ${IMAGE_NAME} | gzip > core-amd64.tar.gz
-      - name: Create artifact from image
-        uses: actions/upload-artifact@v2
-        with:
-          name: core
-          path: core-amd64.tar.gz
+          path: ${{ env.FILE_NAME }}
 
   onboard-arm64:
     runs-on: ubuntu-latest
-    needs: core-arm64
+    needs: core
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:onboard-arm64
       TARGETPLATFORM: linux/arm64
@@ -79,8 +58,8 @@ jobs:
           path: core
       - name: Load core image
         run: |
-          docker load < ./core/core-arm64.tar.gz
-          rm -rf core-arm64
+          docker load < ./core/arm64-core.tar.gz
+          rm -rf core
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
@@ -93,7 +72,7 @@ jobs:
 
   onboard-amd64:
     runs-on: ubuntu-latest
-    needs: core-amd64
+    needs: core
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:onboard-amd64
       TARGETPLATFORM: linux/amd64
@@ -108,8 +87,8 @@ jobs:
           path: core
       - name: Load core image
         run: |
-          docker load < ./core/core-amd64.tar.gz
-          rm -rf core-amd64
+          docker load < ./core/amd64-core.tar.gz
+          rm -rf core
       - name: Setup environment and build
         run: |
           ./.github/workflows/build.sh
@@ -139,7 +118,7 @@ jobs:
   
   landside:
     runs-on: ubuntu-latest
-    needs: core-amd64
+    needs: core
     env:
       IMAGE_NAME: dukerobotics/robosub-ros:landside
       BASE_IMAGE: dukerobotics/robosub-ros:core-amd64
@@ -152,8 +131,8 @@ jobs:
           path: core
       - name: Load core image
         run: |
-          docker load < ./core/core-amd64.tar.gz
-          rm -rf core-amd64
+          docker load < ./core/amd64-core.tar.gz
+          rm -rf core
       - name: Setup environment and build
         working-directory: 
         run: |


### PR DESCRIPTION
Reduces duplication in our autobuild configuration by using a build matrix to specify architectures. Upgrades the download and upload artifact actions to v2.