### PR TITLE
Fix and rename network setup script for landside

### DIFF
--- a/landside/Dockerfile
+++ b/landside/Dockerfile
@@ -30,8 +30,8 @@ RUN wget coppeliarobotics.com/files/CoppeliaSim_Edu_V4_0_0_Ubuntu16_04.tar.xz &&
 ### Final Setup ###
 
 # Add script to setup multiple machines for pool testing
-COPY setup_pool.bash /opt/ros/melodic/setup_pool.bash
-RUN chmod +x /opt/ros/melodic/setup_pool.bash
+COPY setup_network.bash /opt/ros/melodic/setup_network.bash
+RUN chmod +x /opt/ros/melodic/setup_network.bash
 
 # Set computer type
 ENV COMPUTER_TYPE=landside

--- a/landside/setup_network.bash
+++ b/landside/setup_network.bash
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 export ROS_MASTER_URI=http://192.168.1.1:11311
-export ROS_HOSTNAME=localhost


### PR DESCRIPTION
Removes setting ROS_HOSTNAME, since that breaks the actionlib GUI. Probably should not have been there in the first place, since we have no problem with name resolution. Also renames the script to be setup_network since we now need it for local testing with the docker-compose setup.